### PR TITLE
Adds a "harvester" application at /harvester/harvest/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY xproc-z.war /xproc-z.war
 # two distinct instances of the xproc-z.war web app
 COPY tomcat-config/proxy.xml /usr/local/tomcat/conf/Catalina/localhost/
 COPY tomcat-config/harvester.xml /usr/local/tomcat/conf/Catalina/localhost/
+COPY harvest /var/lib/harvest
 # copy the XProc and XSLT source code of the proxy service
 COPY src /src
 # Tomcat is listening on port 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@
 FROM tomcat:9.0.76-jdk21-openjdk-slim
 # Install the XProc-Z servlet
 COPY xproc-z.war /xproc-z.war
-# Copy the Tomcat configuration file which registers the xproc-z.war web app and points it at its main XProc pipeline
+# Copy the Tomcat configuration file which registers the proxy and harvester XProc pipelines as
+# two distinct instances of the xproc-z.war web app
 COPY tomcat-config/proxy.xml /usr/local/tomcat/conf/Catalina/localhost/
+COPY tomcat-config/harvester.xml /usr/local/tomcat/conf/Catalina/localhost/
 # copy the XProc and XSLT source code of the proxy service
 COPY src /src
 # Tomcat is listening on port 8080

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+docker run --publish 8080:8080 --mount type=bind,src=/home/ctuohy/Desktop/TroveProxy/src,dst=/src trove-proxy

--- a/src/xproc/trove-proxy-harvester.xpl
+++ b/src/xproc/trove-proxy-harvester.xpl
@@ -2,7 +2,10 @@
 	xmlns:cx="http://xmlcalabash.com/ns/extensions" 
 	xmlns:p="http://www.w3.org/ns/xproc" 
 	xmlns:c="http://www.w3.org/ns/xproc-step" 
-	xmlns:z="https://github.com/Conal-Tuohy/XProc-Z">
+	xmlns:z="https://github.com/Conal-Tuohy/XProc-Z"
+	xmlns:t="https://github.com/Conal-Tuohy/TroveProxy"
+	xmlns:file="http://exproc.org/proposed/steps/file"
+	xmlns:init-parameters="tag:conaltuohy.com,2015:webapp-init-parameters">
 
 	<p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
@@ -29,5 +32,423 @@
 	
 	<p:import href="xproc-z-library.xpl"/>
 	<z:parse-request/>
-	<z:make-http-response/>
+	<p:group>
+		<p:variable name="path" select="/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value"/>
+		<p:variable name="method" select="upper-case(/c:request/@method)"/>
+		<cx:message>
+			<p:with-option name="message" select="concat('harvester: ', $method, ' ', $path)"/>
+		</cx:message>
+		<p:choose>
+			<p:when test="$path='/harvester/harvest/'">
+				<!-- either GET a list of the existing harvests, or POST a new harvest -->
+				<p:choose>
+					<p:when test="$method = 'POST' ">
+						<t:create-harvest/>
+					</p:when>
+					<p:when test="$method = 'GET' ">
+						<t:list-harvests/>
+					</p:when>
+					<p:otherwise>
+						<z:method-not-allowed>
+							<p:with-option name="method" select="$method"/>
+						</z:method-not-allowed>
+					</p:otherwise>
+				</p:choose>
+			</p:when>
+			<p:when test="starts-with($path, '/harvester/harvest/')">
+				<!-- either a request for a harvest description, a harvest data file, 
+				or an internal request to run a harvest -->
+				<p:variable name="sub-path" select="substring-after($path, '/harvester/harvest/')"/>
+				<p:choose>
+					<p:when test="ends-with($path, '/run')">
+						<p:choose>
+							<p:when test="$method = 'POST' ">
+								<t:run-harvest/>
+							</p:when>
+							<p:otherwise>
+								<z:method-not-allowed>
+									<p:with-option name="method" select="$method"/>
+								</z:method-not-allowed>
+							</p:otherwise>
+						</p:choose>
+					</p:when>
+					<p:when test="ends-with($path, '/')">
+						<t:view-harvest/>
+					</p:when>
+					<p:otherwise>
+						<t:download-data-file/>
+					</p:otherwise>
+				</p:choose>
+			</p:when>
+			<p:otherwise>
+				<p:identity/>
+				<z:make-http-response/>
+			</p:otherwise>
+		</p:choose>
+	</p:group>
+
+	<p:declare-step name="download-data-file" type="t:download-data-file">
+		<p:input port="source"/>
+		<p:output port="result"/>
+		<p:variable name="harvests-directory" select="p:system-property('init-parameters:harvester.harvest-directory')"/>
+		<p:variable name="filename" select="
+			concat(
+				$harvests-directory,
+				substring-after(
+					/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value,
+					'/harvester/harvest/'
+				)
+			)
+		"/>
+		<p:variable name="extension" select="replace($filename, '.*(\..*)', '$1')"/>
+		<p:choose>
+			<p:when test="$extension = '.xml'">
+				<p:load>
+					<p:with-option name="href" select="$filename"/>
+				</p:load>
+				<z:make-http-response/>
+			</p:when>
+			<p:otherwise>
+				<p:template name="load-request">
+					<p:with-param name="url" select="$filename"/>
+					<p:input port="template">
+						<p:inline>
+							<c:request href="{$url}" method="GET" override-content-type="text/plain"/>
+						</p:inline>
+					</p:input>
+				</p:template>
+				<p:http-request/>
+				<p:add-attribute match="/c:body" attribute-name="content-type">
+					<p:with-option name="attribute-value" select="if ($extension = '.csv') then 'text/csv' else 'text/plain'"/>
+				</p:add-attribute>
+				<p:wrap match="/c:body" wrapper="c:response"/>
+				<p:add-attribute match="/c:response" attribute-name="status" attribute-value="200"/>
+			</p:otherwise>
+		</p:choose>
+		<!--
+		<p:identity>
+			<p:input port="source">
+				<p:inline>
+					<c:response status="200">
+						<c:body content-type="text/plain">data file goes here</c:body>
+					</c:response>
+				</p:inline>
+			</p:input>
+		</p:identity>
+		-->
+	</p:declare-step>
+	
+	<p:declare-step name="view-harvest" type="t:view-harvest">
+		<p:input port="source"/>
+		<p:output port="result"/>
+		<p:variable name="path" select="/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value"/>
+		<p:variable name="harvests-directory" select="p:system-property('init-parameters:harvester.harvest-directory')"/>
+		<p:variable name="harvest-name" select="substring-after($path, '/harvester/harvest/')"/>
+		<p:variable name="harvest-directory" select="concat($harvests-directory, $harvest-name)"/>
+		<p:directory-list>
+			<p:with-option name="path" select="$harvest-directory"/>
+		</p:directory-list>
+		<p:viewport match="/c:directory/c:file[@name='status.xml']">
+			<p:load>
+				<p:with-option name="href" select="concat($harvest-directory, '/status.xml')"/>
+			</p:load>
+		</p:viewport>
+		<p:xslt>
+			<p:input port="parameters"><p:empty/></p:input>
+			<p:input port="stylesheet"><p:document href="../xslt/harvester/view-harvest.xsl"/></p:input>
+		</p:xslt>
+		<z:make-http-response content-type="application/xhtml+xml"/>
+	</p:declare-step>
+	
+	<p:declare-step name="list-harvests" type="t:list-harvests">
+		<p:input port="source"/>
+		<p:output port="result"/>
+		<!--
+		<p:variable name="uri-components" select="/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value"/>
+		-->
+		<p:variable name="harvests-directory" select="p:system-property('init-parameters:harvester.harvest-directory')"/>
+
+		<p:variable name="example-harvest-url" select=" 'the URL of your query' "/>
+		<p:directory-list>
+			<p:with-option name="path" select="$harvests-directory"/>
+		</p:directory-list>
+		<p:xslt>
+			<p:with-param name="example-harvest-url" select="$example-harvest-url"/>
+			<p:input port="stylesheet"><p:document href="../xslt/harvester/view-harvests.xsl"/></p:input>
+		</p:xslt>
+		<z:make-http-response content-type="application/xhtml+xml"/>
+	</p:declare-step>
+
+	<p:declare-step name="create-harvest" type="t:create-harvest">
+		<p:input port="source"/>
+		<p:documentation>
+			The output port produces a sequence of two documents: 
+			a <c:response/> to return to the client to point them to the new harvest, and 
+			a <c:request/> to be handled internally by XProc-Z to actually launch the harvest
+		</p:documentation>
+		<p:output port="result" sequence="true"/> 
+		<p:variable name="harvests-uri" select="/c:request/@href"/>
+		<p:variable name="harvester-base-uri" select="
+			/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value 
+			=> substring-before('harvester/harvests/')
+		"/>
+		<p:www-form-urldecode name="post-data">
+			<p:with-option name="value" select="/c:request/c:body[@content-type='application/x-www-form-urlencoded']"/>
+		</p:www-form-urldecode>
+		<p:group>
+			<p:variable name="harvest-name" select="/c:param-set/c:param[@name='name']/@value"/>
+			<p:variable name="harvest-url" select="/c:param-set/c:param[@name='url']/@value"/>
+			<p:variable name="harvests-directory" select="p:system-property('init-parameters:harvester.harvest-directory')"/>
+			<p:variable name="harvest-directory" select="concat($harvests-directory, encode-for-uri($harvest-name))"/>
+			<!--<p:try>-->
+				<p:group>
+					<file:mkdir>
+						<p:with-option name="href" select="$harvest-directory"/>
+					</file:mkdir>
+					<p:template name="create-harvest-initial-state">
+						<p:with-param name="harvest-url" select="$harvest-url"/>
+						<p:input port="source"><p:empty/></p:input>
+						<p:input port="template">
+							<p:inline exclude-inline-prefixes="#all">
+								<harvest
+									status="starting"
+									started="{current-dateTime()}" 
+									last-updated="{current-dateTime()}" 
+									requests="0"
+								>
+									<pending url="{$harvest-url}"/>
+								</harvest>
+							</p:inline>
+						</p:input>
+					</p:template>
+					<p:store indent="true">
+						<p:with-option name="href" select="concat($harvest-directory, '/status.xml')"/>
+					</p:store>
+					<!-- actually launch the harvest -->
+					<p:template name="create-harvest-run-request">
+						<p:with-param name="name" select="$harvest-name"/>
+						<p:input port="source"><p:empty/></p:input>
+						<p:input port="template">
+							<p:inline exclude-inline-prefixes="#all">
+								<c:request href="http://localhost:8080/harvester/harvest/{encode-for-uri($name)}/run" method="POST"/>
+							</p:inline>
+						</p:input>
+					</p:template>
+					<p:template name="redirect-to-new-harvest">
+						<p:with-param name="harvest-name" select="$harvest-name"/>
+						<p:input port="source"><p:empty/></p:input>
+						<p:input port="template">
+							<p:inline>
+								<c:response status="302">
+									<c:header name="Location" value="{encode-for-uri($harvest-name)}/"/>
+								</c:response>
+							</p:inline>
+						</p:input>
+					</p:template>
+					<p:identity name="respond-to-create-and-launch-harvest">
+						<p:input port="source">
+							<p:pipe step="redirect-to-new-harvest" port="result"/>
+							<p:pipe step="create-harvest-run-request" port="result"/>
+						</p:input>
+					</p:identity>
+				</p:group>
+				<!--
+				<p:catch name="failed">
+					<p:identity>
+						<p:input port="source">
+							<p:pipe step="failed" port="error"/>
+						</p:input>
+					</p:identity>
+					<z:make-http-response content-type="application/xml"/>
+				</p:catch>
+			</p:try>
+			-->
+		</p:group>
+	</p:declare-step>
+	
+	<!-- runs in the background -->
+	<p:declare-step name="run-harvest" type="t:run-harvest">
+		<p:input port="source"/>
+		<p:documentation>
+			The output port produces a sequence of two documents: 
+			a <c:response/> which is notionally returned to the client, though XProc-Z will discard it unread 
+			a <c:request/> to be handled internally by XProc-Z to actually launch the harvest
+		</p:documentation>
+		<p:output port="result" sequence="true"/>
+		<p:documentation>
+			Expected input:
+			<c:request xmlns:c="http://www.w3.org/ns/xproc-step" href="/harvester/harvest/test%20of%20harvest3/run" method="POST"/>
+		</p:documentation>
+		<!-- find the harvest folder -->
+		<p:variable name="request-path" select="/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value"/>
+		<p:variable name="harvest-name" select="$request-path => substring-after('/harvester/harvest/') => substring-before('/run')"/>
+		<p:variable name="harvests-directory" select="p:system-property('init-parameters:harvester.harvest-directory')"/>
+		<p:variable name="harvest-directory" select="concat($harvests-directory, $harvest-name)"/>
+		<!-- open the status.xml file -->
+		<p:load name="harvest-status-before-trove-query">
+			<p:with-option name="href" select="concat($harvest-directory, '/status.xml')"/>
+		</p:load>
+		<cx:message>
+			<p:with-option name="message" select="
+				concat(
+					'Harvest &quot;', $harvest-name, '&quot;, ',
+					'created: ', /harvest/@started, ', ',
+					'last updated: ', /harvest/@last-updated, ', ',
+					'status: ', /harvest/@status, ', ',
+					'requests issued: ', /harvest/@requests
+				)
+			"/>
+		</cx:message>
+		<!-- if the harvest is not already complete, run it -->
+		<p:choose name="running-harvest">
+			<p:when test="/harvest/@status='completed'">
+				<!-- the harvest had already completed, so this request to run it should not have been made -->
+				<p:identity>
+					<p:input port="source">
+						<p:inline exclude-inline-prefixes="#all">
+							<c:response status="400"><!-- bad request -->
+								<c:body content-type="text/plain">harvest was already complete</c:body>
+							</c:response>
+						</p:inline>
+					</p:input>
+				</p:identity>
+			</p:when>
+			<p:otherwise>
+				<p:variable name="requests" select="1 + number(/harvest/@requests)"/>
+				<p:variable name="url" select="/harvest/pending[1]/@url"/>
+				<!-- download and save the resource named by the request number -->
+				<p:template name="create-trove-request">
+					<p:with-param name="url" select="$url"/>
+					<p:input port="template">
+						<p:inline exclude-inline-prefixes="#all">
+							<c:request method="GET" href="{$url}" detailed="true"/>
+						</p:inline>
+					</p:input>
+				</p:template>
+				<p:http-request name="data"/>
+				<p:group name="save">
+					<p:variable name="extension" select="
+						if (c:response/c:header[lower-case(@name) = 'content-type']/@value = 'text/csv') then 
+							'.csv' 
+						else 
+							'.xml'
+					"/>
+					<p:variable name="filename" select="
+						concat(
+							format-integer($requests, '296635227'), 
+							$extension
+						)
+					"/>
+					<p:choose>
+						<p:when test="$extension = '.xml'">
+							<p:store name="save-xml" method="xml">
+								<p:input port="source" select="/c:response/c:body/*">
+									<p:pipe step="data" port="result"/>
+								</p:input>
+								<p:with-option name="href" select="concat($harvest-directory, '/', $filename)"/>
+							</p:store>
+						</p:when>
+						<p:otherwise>
+							<p:store name="save-plain-text" method="text">
+								<p:input port="source" select="/c:response/c:body">
+									<p:pipe step="data" port="result"/>
+								</p:input>
+								<p:with-option name="href" select="concat($harvest-directory, '/', $filename)"/>
+							</p:store>
+						</p:otherwise>
+					</p:choose>
+					<!-- update the status.xml file 
+						the incremented request number,
+						remove the downloaded URL,
+						add any new 'next' or 'section' links from the downloaded resource 
+					-->
+					<p:for-each name="new-pending-links">
+						<p:iteration-source select="
+							/c:response/c:header
+								[lower-case(@name)='link']
+								[@value => lower-case() => substring-after(' rel=') = ('next', 'section')]
+						">
+							<p:pipe step="data" port="result"/>
+						</p:iteration-source>
+						<p:output port="result"/>
+						<p:template name="pending-url">
+							<p:with-param name="url" select="substring-before(substring-after(/c:header/@value, '&lt;'), '&gt;')"/>
+							<p:input port="template">
+								<p:inline exclude-inline-prefixes="#all">
+									<pending url="{$url}"/>
+								</p:inline>
+							</p:input>
+						</p:template>
+					</p:for-each>
+					<p:sink/>
+					<p:load name="harvest-status-after-trove-query">
+						<p:with-option name="href" select="concat($harvest-directory, '/status.xml')"/>
+					</p:load>
+					<p:add-attribute match="/harvest" attribute-name="requests">
+						<p:with-option name="attribute-value" select="$requests"/>
+					</p:add-attribute>
+					<p:delete match="/harvest/pending[1]"/>
+					<p:insert match="/harvest" position="last-child">
+						<p:input port="insertion">
+							<p:pipe step="new-pending-links" port="result"/>
+						</p:input>
+					</p:insert>
+					<p:choose>
+						<p:when test="not(/harvest/pending)">
+							<p:add-attribute match="/harvest" attribute-name="status" attribute-value="completed"/>
+							<cx:message>
+								<p:with-option name="message" select="concat('harvester completed harvest &quot;', $harvest-name, '&quot;')"/>
+							</cx:message>
+						</p:when>
+						<p:otherwise>
+							<p:add-attribute match="/harvest" attribute-name="status" attribute-value="running"/>
+						</p:otherwise>
+					</p:choose>
+					<p:add-attribute match="/harvest" attribute-name="last-updated">
+						<p:with-option name="attribute-value" select="current-dateTime()"/>
+					</p:add-attribute>
+					<p:identity name="updated-status"/>
+					<p:store name="save-updated-status" indent="true">
+						<p:with-option name="href" select="concat($harvest-directory, '/status.xml')"/>
+					</p:store>
+					<cx:message cx:depends-on="save-updated-status" message="run-harvest saved updated status">
+						<p:input port="source"><p:empty/></p:input>
+					</cx:message>
+					<p:identity>
+						<p:input port="source">
+							<p:pipe step="updated-status" port="result"/>
+						</p:input>
+					</p:identity>
+					<p:choose>
+						<p:when test="/harvest/@status='completed'">
+							<!-- respond with a "finished" message -->
+							<p:identity name="harvest-complete">
+								<p:input port="source">
+									<p:inline>
+										<c:response status="200">
+											<c:body content-type="text/plain">harvest complete</c:body>
+										</c:response>
+									</p:inline>
+								</p:input>
+							</p:identity>
+						</p:when>
+						<p:otherwise>
+							<p:identity name="harvest-continuing">
+								<p:input port="source">
+									<p:inline>
+										<c:response status="202"><!-- accepted for ongoing processing -->
+											<c:body content-type="text/plain">harvest continuing</c:body>
+										</c:response>
+									</p:inline>
+									<!-- repeat the current request -->
+									<p:pipe step="run-harvest" port="source"/>
+								</p:input>
+							</p:identity>
+						</p:otherwise>
+					</p:choose>
+				</p:group>
+			</p:otherwise>
+		</p:choose>
+	</p:declare-step>
+		
 </p:declare-step>

--- a/src/xproc/trove-proxy-harvester.xpl
+++ b/src/xproc/trove-proxy-harvester.xpl
@@ -1,0 +1,33 @@
+<p:declare-step version="1.0" name="trove-proxy"
+	xmlns:cx="http://xmlcalabash.com/ns/extensions" 
+	xmlns:p="http://www.w3.org/ns/xproc" 
+	xmlns:c="http://www.w3.org/ns/xproc-step" 
+	xmlns:z="https://github.com/Conal-Tuohy/XProc-Z">
+
+	<p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
+
+	<p:input port='source' primary='true'/>
+	<!-- e.g.
+		<request xmlns="http://www.w3.org/ns/xproc-step"
+		  method = NCName
+		  href? = anyURI
+		  detailed? = boolean
+		  status-only? = boolean
+		  username? = string
+		  password? = string
+		  auth-method? = string
+		  send-authorization? = boolean
+		  override-content-type? = string>
+			 (c:header*,
+			  (c:multipart |
+				c:body)?)
+		</request>
+	-->
+	
+	<p:input port='parameters' kind='parameter' primary='true'/>
+	<p:output port="result" primary="true" sequence="true"/>
+	
+	<p:import href="xproc-z-library.xpl"/>
+	<z:parse-request/>
+	<z:make-http-response/>
+</p:declare-step>

--- a/src/xproc/trove-proxy.xpl
+++ b/src/xproc/trove-proxy.xpl
@@ -59,7 +59,9 @@
 	<z:parse-request name="parsed-request"/>
 	
 	<!--debug-->
+	<!--
 	<z:dump href="/tmp/parsed-request.xml" indent="true"/>
+	-->
 	
 	<p:choose name="generate-either-citation-metadata-or-query-results">
 		<p:variable name="proxy-metadata-format" select="/c:request/c:param-set[@xml:id='parameters']/c:param[@name='proxy-metadata-format']/@value"/>
@@ -122,9 +124,11 @@
 			Parameters which are directed at the proxy server itself, rather than at the Trove API, such as proxy-format, 
 			are recorded so that they can be appended to URIs returned in Trove responses
 		</p:documentation>
-		<p:variable name="proxy-parameters" select="
+		<p:variable name="proxy-parameter-string" select="
 			string-join(
-				/c:request/c:param-set[@xml:id='parameters']/c:param[starts-with(@name, 'proxy-')]/concat(@name, '=', @value),
+				/c:request/c:param-set[@xml:id='parameters'] (: the URI parameters :)
+					/c:param[starts-with(@name, 'proxy-')][@value != ''] (: ... whose name starts with 'proxy-' and which have a non-null value :)
+						/concat(@name, '=', @value), (: stick the name and value together :)
 				'&amp;'
 			)
 		"/>
@@ -137,10 +141,16 @@
 			</p:input>
 		</p:xslt>
 		
+		<!--
 		<z:dump href="/tmp/trove-http-request.xml"/>
+		-->
 		
 		<p:documentation>Actually issue the request to the Trove API and receive a response</p:documentation>
 		<p:http-request name="issue-request-to-trove-api"/>
+		
+		<!--
+		<z:dump href="/tmp/trove-http-response.xml"/>
+		-->
 		
 		<p:documentation>Fix corrigible errors in the response received from Trove</p:documentation>
 		<p:xslt name="fix-trove-response">
@@ -157,7 +167,7 @@
 			<p:with-param name="request-uri" select="$request-uri"/>
 			<p:with-param name="proxy-base-uri" select="$proxy-base-uri"/>
 			<p:with-param name="upstream-base-uri" select="$upstream-base-uri"/>
-			<p:with-param name="proxy-parameters" select="$proxy-parameters"/>
+			<p:with-param name="proxy-parameter-string" select="$proxy-parameter-string"/>
 			<p:input port="stylesheet">
 				<p:document href="../xslt/rewrite-trove-uris-as-proxy-uris.xsl"/>
 			</p:input>

--- a/src/xproc/trove-proxy.xpl
+++ b/src/xproc/trove-proxy.xpl
@@ -267,52 +267,6 @@
 		</p:choose>
 	</p:declare-step>
 
-	<p:declare-step name="parse-request" type="z:parse-request">
-		<!-- TODO decide if the c:param-set[@xml:id='uri'] is even needed in the output -->
-		<p:documentation>
-			Parses an HTTP request (<c:request/> element) received by the proxy.
-			The result document is the same <c:request/> with two additional child <c:param-set/> elements,
-			one containing the request URI parsed into its main components, and the other containing
-			the set of parameters in the query portion of the URI.
-			e.g.
-			<c:request href="http://localhost:8080" method="get">
-				<c:param-set xml:id="uri">
-					<c:param name="scheme" value="http or https"/>
-					<c:param name="host" value="the host name"/>
-					<c:param name="port" value="either a port number, or blank"/>
-					<c:param name="path" value="the component of the request URI preceding any '?' character"/>
-					<c:param name="query" value="the query portion of the URI"/>
-				</c:param-set>
-				<c:param-set xml:id="parameters">
-					<c:param name="q" value="Mr Right"/>
-					<c:param name="bulkHarvest" value="true"/>
-					<c:param name="key" value="XXXXXXXXXX-1234567890-ABCDEFGHIJ"/>
-					<c:param name="category" value="newspaper"/>
-					<c:param name="category" value="book"/>
-				</c:param-set>
-				<c:header name="accept" value="application/xml"/>
-				<c:header name="X-API-KEY" value="XXXXXXXXXX-1234567890-ABCDEFGHIJ"/>
-			</c:request>
-		</p:documentation>
-		<p:input port="source"/>
-		<p:output port="result"/>
-		<z:parse-request-uri unproxify="true"/>
-		<p:add-attribute name="uri" match="/*" attribute-name="xml:id" attribute-value="uri"/>
-		<p:www-form-urldecode>
-			<p:with-option name="value" select="substring-after(/c:param-set/c:param[@name='query']/@value, '?')"/>
-		</p:www-form-urldecode>
-		<p:add-attribute name="parameters" match="/*" attribute-name="xml:id" attribute-value="parameters"/>
-		<p:insert name="parsed-request" match="/*" position="first-child">
-			<p:input port="source">
-				<p:pipe step="parse-request" port="source"/>
-			</p:input>
-			<p:input port="insertion">
-				<p:pipe step="uri" port="result"/>
-				<p:pipe step="parameters" port="result"/>
-			</p:input>
-		</p:insert>
-	</p:declare-step>
-	
 	<p:declare-step name="enhance-people-data" type="z:enhance-people-data">
 		<p:option name="include-people-australia"/>
 		<p:documentation>

--- a/src/xproc/trove-proxy.xpl
+++ b/src/xproc/trove-proxy.xpl
@@ -57,7 +57,23 @@
 		</c:request>
 	</p:documentation>
 	<z:parse-request name="parsed-request"/>
-	
+	<p:group name="access-log">
+		<cx:message>
+			<p:with-option name="message" select="
+				string-join(
+					(
+						'proxy:', 
+						upper-case(/c:request/@method), 
+						/c:request/@href
+(:						/c:request/c:param-set[@xml:id='uri']/c:param[@name='path']/@value,
+						for $p in /c:request/c:param-set[@xml:id='parameters']/c:param return $p/@name || '=' || $p/@value
+:)
+					),
+					' '
+				)
+			"/>
+		</cx:message>
+	</p:group>
 	<!--debug-->
 	<!--
 	<z:dump href="/tmp/parsed-request.xml" indent="true"/>
@@ -142,15 +158,15 @@
 		</p:xslt>
 		
 		<!--
-		<z:dump href="/tmp/trove-http-request.xml"/>
 		-->
+		<z:dump href="/tmp/trove-http-request.xml"/>
 		
 		<p:documentation>Actually issue the request to the Trove API and receive a response</p:documentation>
 		<p:http-request name="issue-request-to-trove-api"/>
 		
 		<!--
-		<z:dump href="/tmp/trove-http-response.xml"/>
 		-->
+		<z:dump href="/tmp/trove-http-response.xml"/>
 		
 		<p:documentation>Fix corrigible errors in the response received from Trove</p:documentation>
 		<p:xslt name="fix-trove-response">

--- a/src/xproc/xproc-z-library.xpl
+++ b/src/xproc/xproc-z-library.xpl
@@ -522,5 +522,50 @@
 			<p:with-option name="indent" select="$indent"/>
 		</p:store>
 	</p:declare-step>
-	
+
+	<p:declare-step name="parse-request" type="z:parse-request">
+		<!-- TODO decide if the c:param-set[@xml:id='uri'] is even needed in the output -->
+		<p:documentation>
+			Parses an HTTP request (<c:request/> element) received by the proxy.
+			The result document is the same <c:request/> with two additional child <c:param-set/> elements,
+			one containing the request URI parsed into its main components, and the other containing
+			the set of parameters in the query portion of the URI.
+			e.g.
+			<c:request href="http://localhost:8080" method="get">
+				<c:param-set xml:id="uri">
+					<c:param name="scheme" value="http or https"/>
+					<c:param name="host" value="the host name"/>
+					<c:param name="port" value="either a port number, or blank"/>
+					<c:param name="path" value="the component of the request URI preceding any '?' character"/>
+					<c:param name="query" value="the query portion of the URI"/>
+				</c:param-set>
+				<c:param-set xml:id="parameters">
+					<c:param name="q" value="Mr Right"/>
+					<c:param name="bulkHarvest" value="true"/>
+					<c:param name="key" value="XXXXXXXXXX-1234567890-ABCDEFGHIJ"/>
+					<c:param name="category" value="newspaper"/>
+					<c:param name="category" value="book"/>
+				</c:param-set>
+				<c:header name="accept" value="application/xml"/>
+				<c:header name="X-API-KEY" value="XXXXXXXXXX-1234567890-ABCDEFGHIJ"/>
+			</c:request>
+		</p:documentation>
+		<p:input port="source"/>
+		<p:output port="result"/>
+		<z:parse-request-uri unproxify="true"/>
+		<p:add-attribute name="uri" match="/*" attribute-name="xml:id" attribute-value="uri"/>
+		<p:www-form-urldecode>
+			<p:with-option name="value" select="substring-after(/c:param-set/c:param[@name='query']/@value, '?')"/>
+		</p:www-form-urldecode>
+		<p:add-attribute name="parameters" match="/*" attribute-name="xml:id" attribute-value="parameters"/>
+		<p:insert name="parsed-request" match="/*" position="first-child">
+			<p:input port="source">
+				<p:pipe step="parse-request" port="source"/>
+			</p:input>
+			<p:input port="insertion">
+				<p:pipe step="uri" port="result"/>
+				<p:pipe step="parameters" port="result"/>
+			</p:input>
+		</p:insert>
+	</p:declare-step>	
 </p:library>

--- a/src/xproc/xproc-z-library.xpl
+++ b/src/xproc/xproc-z-library.xpl
@@ -161,6 +161,32 @@
 		</p:identity>
 	</p:pipeline>
 	
+	<p:pipeline type="z:method-not-allowed">
+		<p:option name="method" required="true"/>
+		<p:template>
+			<p:with-param name="method" select="$method"/>
+			<p:input port="template">
+				<p:inline>
+					<c:response status="405">
+						<c:header name="X-Powered-By" value="XProc using XML Calabash"/>
+						<c:header name="Server" value="XProc-Z"/>
+						<c:body content-type="application/xhtml+xml">
+							<html xmlns="http://www.w3.org/1999/xhtml">
+								<head>
+									<title>Method Not Allowed</title>
+								</head>
+								<body>
+									<h1>Method Not Allowed</h1>
+									<p>The {$method} method is not allowed on this resource.</p>
+								</body>
+							</html>
+						</c:body>
+					</c:response>
+				</p:inline>
+			</p:input>
+		</p:template>
+	</p:pipeline>
+
 	<p:pipeline type="z:parse-parameters">
 		<p:xslt>
 			<p:input port="stylesheet">

--- a/src/xslt/harvester/view-harvest.xsl
+++ b/src/xslt/harvester/view-harvest.xsl
@@ -1,0 +1,55 @@
+<xsl:stylesheet version="3.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:c="http://www.w3.org/ns/xproc-step"
+	xmlns="http://www.w3.org/1999/xhtml"
+	expand-text="true"
+>
+	<xsl:param name="harvests-uri"/>
+	<xsl:param name="name"/>
+	<xsl:template match="/c:directory">
+		<html>
+			<head>
+				<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8"/>
+				<title>{@name}</title>
+				<style xsl:expand-text="false">
+					body {
+						font-family: sans-serif;
+					}
+					th {
+						text-align: left;
+					}
+					div.status {
+						background-color: #FCF7E8;
+						padding: 1em;
+					}
+				</style>
+			</head>
+			<body>
+				<h1>{@name}</h1>
+				<xsl:apply-templates select="harvest"/>
+				<h2>Data files</h2>
+				<ul class="files">
+					<xsl:for-each select="c:file">
+						<xsl:sort select="@name"/>
+						<li><a href="{@name}">{@name}</a></li>
+					</xsl:for-each>
+				</ul>
+			</body>
+		</html>
+	</xsl:template>
+	
+	<xsl:template match="harvest">
+		<xsl:variable name="date-format" select=" '[Y0001]-[M01]-[D01] [H01]:[m01]:[s01] [z,6-6]' "/>
+		<div class="status">
+			<h2>Harvest status</h2>
+			<table>
+				<tr><th>status</th><td>{@status}</td></tr>
+				<tr><th>requests</th><td>{@requests}</td></tr>
+				<tr><th>started</th><td>{format-dateTime(@started, $date-format)}</td></tr>
+				<tr><th>updated</th><td>{format-dateTime(@last-updated, $date-format)}</td></tr>
+			</table>
+			<p class="table-footnote"><a href="status.xml">Download status file</a></p>
+		</div>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/src/xslt/harvester/view-harvests.xsl
+++ b/src/xslt/harvester/view-harvests.xsl
@@ -1,0 +1,52 @@
+<xsl:stylesheet version="3.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:c="http://www.w3.org/ns/xproc-step"
+	xmlns="http://www.w3.org/1999/xhtml"
+>
+	<xsl:param name="example-harvest-url"/>
+	<xsl:template match="/c:directory">
+		<html>
+			<head>
+				<title>Harvests</title>
+				<style type="text/css">
+					body, input, select, button {
+						font-family: sans-serif;
+					}
+					h1 {
+						text-align: center;
+					}
+					form {
+						display: grid;
+						grid-template-columns: 8em 1fr;
+						gap: 0.5em;
+					}
+					form label {
+						text-align: right;
+						font-size: 0.8em;
+					}
+				</style>
+			</head>
+			<body>
+				<h1>Harvests</h1>
+				<xsl:choose>
+					<xsl:when test="c:directory">
+						<xsl:for-each select="c:directory">
+							<p><a href="{encode-for-uri(@name)}/"><xsl:value-of select="@name"/></a></p>
+						</xsl:for-each>
+					</xsl:when>
+					<xsl:otherwise>
+						<p>There are no harvests.</p>
+					</xsl:otherwise>
+				</xsl:choose>
+				<h2>Begin a new harvest</h2>
+				<form method="POST" target="">
+					<label for="name">Name</label>
+					<input type="text" xml:id="name" name="name" placeholder="my harvest"/>
+					<label for="url">URL</label>
+					<input type="text" xml:id="url" name="url" placeholder="{$example-harvest-url}"/>
+					<button type="submit">Begin harvest</button>
+				</form>
+			</body>
+		</html>
+	</xsl:template>
+</xsl:stylesheet>

--- a/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
+++ b/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
@@ -62,6 +62,16 @@
 			<xsl:copy-of select="@*"/>
 			<!-- TODO actually canonicalise this URI, removing any API key parameter from it, sorting the params in alpha order, etc -->
 			<c:header name="Link" value="&lt;{$request-uri}&gt;; rel=canonical"/>
+			<!-- add link to metadata -->
+			<c:header name="Link" value="&lt;{
+				string-join(
+					($request-uri, 'proxy-metadata-format=ro-crate'), 
+					if (contains($request-uri, '?')) then
+						'&amp;'
+					else
+						'?'
+				)
+			}&gt;; rel=describes"/>
 			<xsl:variable name="next-links" select="//*/@next"/>
 			<xsl:for-each select="$next-links">
 				<xsl:variable name="url">

--- a/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
+++ b/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
@@ -71,7 +71,7 @@
 					else
 						'?'
 				)
-			}&gt;; rel=describes"/>
+			}&gt;; rel=describedby"/>
 			<xsl:variable name="next-links" select="//*/@next"/>
 			<xsl:for-each select="$next-links">
 				<xsl:variable name="url">

--- a/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
+++ b/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
@@ -25,7 +25,9 @@
 			else (: parameter missing; effective value = 1 :)
 				'1' 
 		"/>
+		<!--
 		<xsl:message expand-text="true">parameters: {$parameters}, parameter: {$proxy-max-requests-parameter}, effective value: {$max-requests}</xsl:message>
+		-->
 
 		<!-- output a URL unless this is a "next" url and max-requests has already fallen to 1 -->
 		<xsl:if test="not(local-name() = 'next' and $max-requests = '1')">

--- a/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
+++ b/src/xslt/rewrite-trove-uris-as-proxy-uris.xsl
@@ -4,18 +4,54 @@
 	<xsl:param name="request-uri"/>
 	<xsl:param name="proxy-base-uri"/>
 	<xsl:param name="upstream-base-uri"/>
-	<xsl:param name="proxy-parameters"/>
+	<xsl:param name="proxy-parameter-string"/>
 	
+	<!-- TODO comment and tidy up -->
 	<xsl:template name="rewrite-uri">
-		<xsl:sequence select="
-			concat(
-				$proxy-base-uri,
-				substring-after(., $upstream-base-uri),
-				(: add the proxy parameters such as proxy-format onto the URI :)
-				if (contains(., '?')) then '&amp;' else '?', 
-				$proxy-parameters
-			)
+		<xsl:variable name="query-component" select="replace(., '^.*(\?.*)$', '$1')"/>
+		<xsl:variable name="uri-before-query-component" select="substring-before(., $query-component)"/>
+		<xsl:variable name="parameters" select="$query-component => substring-after('?') => tokenize('&amp;')"/>
+		<xsl:variable name="proxy-parameters" select="$proxy-parameter-string => tokenize('&amp;')"/>
+		<xsl:variable name="proxy-max-requests-parameter" select="$proxy-parameters[starts-with(., 'proxy-max-requests=')]"/>
+		<xsl:variable name="max-requests" select="
+			if ($proxy-max-requests-parameter) then
+				let 
+					$proxy-max-requests-value:= substring-after($proxy-max-requests-parameter, '=')
+				return
+					if ($proxy-max-requests-value = '') then 
+						'1' (: parameter value missing; effective value = 1 :)
+					else
+						$proxy-max-requests-value
+			else (: parameter missing; effective value = 1 :)
+				'1' 
 		"/>
+		<xsl:message expand-text="true">parameters: {$parameters}, parameter: {$proxy-max-requests-parameter}, effective value: {$max-requests}</xsl:message>
+
+		<!-- output a URL unless this is a "next" url and max-requests has already fallen to 1 -->
+		<xsl:if test="not(local-name() = 'next' and $max-requests = '1')">
+			<xsl:sequence select="
+				string-join(
+					(
+						concat(
+							$proxy-base-uri,
+							substring-after(., $upstream-base-uri)
+						),
+						(: copy all the proxy parameters such as proxy-format back onto the URI :)
+						(: but discarding parameters with null values, and specifically excluding the 
+						proxy-max-requests parameter which will be appended with a decremented value :)
+						$proxy-parameters[normalize-space()][not(starts-with(., 'proxy-max-requests='))],
+						(: append add the proxy-max-requests parameter, decremented by one, but only if 
+						the parameter exists and has not reached 0, and only for @next URLs, not @url, 
+						because the @url attributes point to leaf resources without further @next links :)
+						if (local-name(.) = 'url') then 
+							() (: omit the @next parameter altogether :) 
+						else 
+							concat('proxy-max-requests=', number($max-requests) - 1)
+					),
+					if (contains(., '?')) then '&amp;' else '?'
+				)
+			"/>
+		</xsl:if>
 	</xsl:template>
 	
 	<!-- remove any "canonical" link because we will be adding a new one pointing to the proxied URL -->
@@ -26,14 +62,33 @@
 			<xsl:copy-of select="@*"/>
 			<!-- TODO actually canonicalise this URI, removing any API key parameter from it, sorting the params in alpha order, etc -->
 			<c:header name="Link" value="&lt;{$request-uri}&gt;; rel=canonical"/>
+			<xsl:variable name="next-links" select="//*/@next"/>
+			<xsl:for-each select="$next-links">
+				<xsl:variable name="url">
+					<xsl:call-template name="rewrite-uri"/>
+				</xsl:variable>
+				<xsl:if test="normalize-space($url)">
+					<xsl:choose>
+						<xsl:when test="count($next-links) = 1">
+							<c:header name="Link" value="&lt;{$url}&gt;; rel=next"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<c:header name="Link" value="&lt;{$url}&gt;; rel=section"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:if>
+			</xsl:for-each>
 			<xsl:apply-templates/>
 		</xsl:copy>
 	</xsl:template>
 	
 	<xsl:template match="@next | @url">
-		<xsl:attribute name="{local-name()}">
+		<xsl:variable name="url">
 			<xsl:call-template name="rewrite-uri"/>
-		</xsl:attribute>
+		</xsl:variable>
+		<xsl:if test="normalize-space($url)">
+			<xsl:attribute name="{local-name()}" select="$url"/>
+		</xsl:if>
 	</xsl:template>
-
+	
 </xsl:stylesheet>

--- a/tomcat-config/harvester.xml
+++ b/tomcat-config/harvester.xml
@@ -1,3 +1,4 @@
 <Context docBase='/xproc-z.war'>
 	<Parameter name="xproc-z.main" value="/src/xproc/trove-proxy-harvester.xpl" override="false"/>
+	<Parameter name="harvester.harvest-directory" value="/var/lib/harvest/" />
 </Context>

--- a/tomcat-config/harvester.xml
+++ b/tomcat-config/harvester.xml
@@ -1,0 +1,3 @@
+<Context docBase='/xproc-z.war'>
+	<Parameter name="xproc-z.main" value="/src/xproc/trove-proxy-harvester.xpl" override="false"/>
+</Context>


### PR DESCRIPTION
There should be a home page for the app at `/harvester/` but there isn't (yet). The URL `/harvester/harvest/` shows a list of existing harvests and a form where you can add a new one. 

But in general my intention is that it would be integrated by having some other JS code make an HTTP POST to `/harvester/harvest/` with `www-form-urlencoded` parameters `url` being a query URL (of the proxy) and `name` being a name for a new harvest. The result is returns a returns a redirect to an HTML page representing the harvest, e.g. `/harvester/harvest/my%20harvest/`. You can refresh the page and see the harvesting going on in the background. You can see a list of the harvested files, and download them directly. 